### PR TITLE
`vendor` フォルダを除外するように設定すればよいらしい。

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ include:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - vendor
 
 highlighter: rouge
 


### PR DESCRIPTION
http://blog.eiel.info/blog/2014/01/22/exclude-vendor-on-jekyll/